### PR TITLE
Fix newline behvaior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,11 +42,11 @@ const DEFAULT_RULES = {
   },
 
   hardbreak() {
-    return [['br']];
+    return '\n';
   },
 
   softbreak(token, attrs, children, options) {
-    return options.breaks ? [['br']] : '\n';
+    return '\n';
   },
 
   text(token) {

--- a/src/index.js
+++ b/src/index.js
@@ -42,11 +42,11 @@ const DEFAULT_RULES = {
   },
 
   hardbreak() {
-    return '\n';
+    return '\n\n';
   },
 
   softbreak(token, attrs, children, options) {
-    return '\n';
+    return options.breaks ? '\n\n' : '\n';
   },
 
   text(token) {


### PR DESCRIPTION
Fixes br with children

Uncaught (in promise) Error: br is a void element tag and must neither have `children` nor use `dangerouslySetInnerHTML`. Check the render method of EntryMarkdownView.

This is an example for the text that causes problem:
**[\u200e8/\u200e18/\u200e2016 10:53 AM] kuku: **
Hi Mike. I saw your ticket about suspicious activity. Is there any background you can give me into why something is suspected?
**[\u200e8/\u200e18/\u200e2016 11:01 AM] kuku:** 
Hi kiki, keke has resolved the issue with the help of Travis. It was a sync issue with Sophos SafeGuard. The ticket # is 7777.  I was not able to login after I lock my computer when I walked away.  I kept trying the new password I setup this morning an it would not let me in. I decided to restart and the message I received was that if I restarted the other users using my machine would be logged off.  So at that point I shut down the computer.  
**[\u200e8/\u200e18/\u200e2016 11:02 AM] koko:** 
Ok, sounds good. Thanks for info.
